### PR TITLE
Fix decryption of ciphertext created with 'header' => 'randomiv'

### DIFF
--- a/lib/Crypt/CBC.pm
+++ b/lib/Crypt/CBC.pm
@@ -661,7 +661,7 @@ sub _read_key_and_iv {
 	croak "Ciphertext does not begin with a valid header for 'randomiv' header mode" unless defined $self->{iv};
 	croak "randomiv header mode cannot be used securely when decrypting with a >8 byte block cipher.\n"
 	    unless $self->blocksize == 8;
-	(undef,$self->{key}) = $self->pbkdf_obj->key_and_iv(undef,$self->{passphrase});
+	($self->{key},undef) = $self->pbkdf_obj->key_and_iv(undef,$self->{passphrase});
 	substr($$input_stream,0,16) = ''; # truncate
     }
 


### PR DESCRIPTION
Patch originally from Paulo Andrade: https://bugzilla.redhat.com/show_bug.cgi?id=2235322

The function `sub key_and_iv ()` in the module `Crypt/CBC/PBKDF.pm` returns two values: `key` and `iv`

In `sub _read_key_and_iv` in `Crypt/CBC.pm`, the key is set from the second return value rather than the first, causing decryption failures (#6).

This commit changes `sub _read_key_and_iv` to use the first value instead, fixing the problem.